### PR TITLE
Fix packaging configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup, find_packages
 setup(
     name='zeroth',
     version='0.1',
-    packages=find_packages(),
+    packages=find_packages(include=["core"]),
+    py_modules=["cli_interface", "api_interface", "config"],
     install_requires=[
         'neo4j',
         'openai',


### PR DESCRIPTION
## Summary
- include `core` as a package and list top-level modules via `py_modules`
- add missing `core/__init__.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install .`


------
https://chatgpt.com/codex/tasks/task_e_6852fc38c694832c9aa7c698266ca4f0