### PR TITLE
Implement MemoryAgent close and use in CLI/API

### DIFF
--- a/api_interface.py
+++ b/api_interface.py
@@ -19,6 +19,12 @@ llm = LLM_Agent()
 explainer = ExplainerAgent()
 ingestor = DocumentIngestor(llm, memory)
 
+
+@app.on_event("shutdown")
+def shutdown_event():
+    logger.info("Shutting down MemoryAgent")
+    memory.close()
+
 class TaskRequest(BaseModel):
     goal: str
 

--- a/cli_interface.py
+++ b/cli_interface.py
@@ -16,18 +16,19 @@ def main():
 
     explanation_trace = []
 
-    while True:
-        print("\n=== Zeroth CLI ===")
-        print("1. Plan & Reason a Goal")
-        print("2. Learn a Fact Manually")
-        print("3. Ingest a Document")
-        print("4. Query Memory")
-        print("5. Explain Last Output")
-        print("6. Exit")
+    try:
+        while True:
+            print("\n=== Zeroth CLI ===")
+            print("1. Plan & Reason a Goal")
+            print("2. Learn a Fact Manually")
+            print("3. Ingest a Document")
+            print("4. Query Memory")
+            print("5. Explain Last Output")
+            print("6. Exit")
 
-        choice = input("Select an option (1-6): ").strip()
+            choice = input("Select an option (1-6): ").strip()
 
-        if choice == '1':
+            if choice == '1':
             # Reset explanation trace for each new reasoning cycle
             explanation_trace = []
             user_goal = input("Enter your goal: ").strip()
@@ -51,13 +52,13 @@ def main():
             print("\n--- Explanation Trace ---")
             print(explainer.explain(explanation_trace))
 
-        elif choice == '2':
+            elif choice == '2':
             fact = input("Enter fact name: ").strip()
             value = input("Enter fact value: ").strip()
             memory.store(fact, value, source="user")
             print("Fact stored successfully.")
 
-        elif choice == '3':
+            elif choice == '3':
             print("Choose document ingestion method:")
             print("1. Paste manually")
             print("2. Upload from file (in ./uploads)")
@@ -83,24 +84,27 @@ def main():
 
             print("Document processed and facts stored.")
 
-        elif choice == '4':
+            elif choice == '4':
             query = input("Enter fact name to query: ").strip()
             result = memory.retrieve(query)
             print(f"Fact: {result or '[Not Found]'}")
 
-        elif choice == '5':
+            elif choice == '5':
             if explanation_trace:
                 print("\n--- Last Explanation ---")
                 print(explainer.explain(explanation_trace))
             else:
                 print("No previous explanation found.")
 
-        elif choice == '6':
+            elif choice == '6':
             print("Exiting Zeroth CLI. Goodbye!")
             break
 
-        else:
-            print("Invalid option. Try again.")
+            else:
+                print("Invalid option. Try again.")
+
+    finally:
+        memory.close()
 
 if __name__ == '__main__':
     main()

--- a/core/memory_agent.py
+++ b/core/memory_agent.py
@@ -12,6 +12,12 @@ class MemoryAgent:
             auth=(Config.NEO4J_USER, Config.NEO4J_PASSWORD),
         )
 
+    def close(self):
+        """Close the underlying Neo4j driver connection."""
+        logger.info("Shutting down MemoryAgent driver")
+        if self.driver is not None:
+            self.driver.close()
+
     def retrieve(self, query):
         logger.debug("Retrieving fact '%s'", query)
         with self.driver.session() as session:


### PR DESCRIPTION
## Summary
- add `close` method to `MemoryAgent`
- ensure CLI closes the `MemoryAgent` with a `finally` block
- close `MemoryAgent` on FastAPI shutdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853025bd374832cba0c56497ea348a2