### PR TITLE
Add LLM agent tests and use configurable upload paths

### DIFF
--- a/api_interface.py
+++ b/api_interface.py
@@ -2,6 +2,7 @@ import os
 import logging
 from fastapi import FastAPI
 from pydantic import BaseModel
+from config import Config
 from core.planner_agent import PlannerAgent
 from core.memory_agent import MemoryAgent
 from core.reasoner_agent import ReasonerAgent
@@ -42,7 +43,7 @@ class IngestRequest(BaseModel):
     content: str
 
 class IngestFileRequest(BaseModel):
-    """Request body for ingesting a file from ``uploads`` directory."""
+    """Request body for ingesting a file from the upload directory."""
 
     filename: str  # Name of a text file located in Config.UPLOAD_DIR
 
@@ -81,9 +82,9 @@ def ingest(req: IngestRequest):
 
 @app.post("/ingest-file")
 def ingest_file(req: IngestFileRequest):
-    """Load a text file from ``uploads`` and ingest its contents."""
+    """Load a text file from the upload directory and ingest its contents."""
 
-    filepath = os.path.join("uploads", req.filename)
+    filepath = os.path.join(Config.UPLOAD_DIR, req.filename)
     logger.info("/ingest-file loading %s", filepath)
     if not os.path.exists(filepath):
         return {"error": "File not found"}

--- a/cli_interface.py
+++ b/cli_interface.py
@@ -5,6 +5,7 @@ from core.reasoner_agent import ReasonerAgent
 from core.llm_agent import LLM_Agent
 from core.explainer_agent import ExplainerAgent
 from core.document_ingestor import DocumentIngestor
+from config import Config
 
 def main():
     """Launch the interactive command line interface."""
@@ -63,12 +64,12 @@ def main():
             elif choice == '3':
             print("Choose document ingestion method:")
             print("1. Paste manually")
-            print("2. Upload from file (in ./uploads)")
+            print(f"2. Upload from file (in {Config.UPLOAD_DIR})")
             doc_option = input("Select (1 or 2): ").strip()
 
             if doc_option == '2':
-                filename = input("Enter filename (from ./uploads): ").strip()
-                filepath = os.path.join("uploads", filename)
+                filename = input(f"Enter filename (from {Config.UPLOAD_DIR}): ").strip()
+                filepath = os.path.join(Config.UPLOAD_DIR, filename)
                 if not os.path.exists(filepath):
                     print("File not found.")
                     continue

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Minimal openai stub so LLM_Agent can be imported without the real dependency
+openai_stub = types.ModuleType("openai")
+class _DummyChatCompletion:
+    @staticmethod
+    def create(*args, **kwargs):
+        raise NotImplementedError
+
+openai_stub.ChatCompletion = _DummyChatCompletion
+openai_stub.api_key = None
+sys.modules.setdefault("openai", openai_stub)
+
+from core.llm_agent import LLM_Agent
+from config import Config
+import pytest
+
+
+def _dummy_response(text):
+    msg = types.SimpleNamespace(content=text)
+    choice = types.SimpleNamespace(message=msg)
+    return types.SimpleNamespace(choices=[choice])
+
+
+def test_llm_agent_query_factual(monkeypatch):
+    captured = {}
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _dummy_response("ok")
+    monkeypatch.setattr(openai_stub.ChatCompletion, "create", fake_create)
+    agent = LLM_Agent()
+    result = agent.query("goal", mode="factual")
+    assert result == "ok"
+    assert captured["temperature"] == 0.2
+    assert captured["max_tokens"] == 300
+    assert "factual assistant" in captured["messages"][0]["content"]
+    assert openai_stub.api_key == Config.OPENAI_API_KEY
+
+
+def test_llm_agent_query_creative(monkeypatch):
+    captured = {}
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _dummy_response("creative")
+    monkeypatch.setattr(openai_stub.ChatCompletion, "create", fake_create)
+    agent = LLM_Agent()
+    result = agent.query("goal", mode="creative")
+    assert result == "creative"
+    assert captured["temperature"] == 0.7
+    assert captured["max_tokens"] == 500
+    assert "Be creative" in captured["messages"][0]["content"]
+
+
+def test_llm_agent_query_error(monkeypatch):
+    def fake_create(**kwargs):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(openai_stub.ChatCompletion, "create", fake_create)
+    agent = LLM_Agent()
+    result = agent.query("goal")
+    assert result.startswith("[LLM ERROR:")


### PR DESCRIPTION
## Summary
- add tests for LLM_Agent
- use `Config.UPLOAD_DIR` instead of hard coded `uploads` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685307ae1e0c832ca7a2f762f3feedd9