### PR TITLE
Prompt for env vars on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,37 @@ For a deeper look at the project's philosophy and detailed use cases, see the [W
 - **Explainable reasoning** – every step can be traced and explained to the user
 - **CLI and REST API** – interact either from the command line or over HTTP
 - **Document ingestion** – parse text files and extract facts automatically
+## Quick start
+1. **Install the package** (see Installation below).
+2. **Run** `python cli_interface.py` for the CLI or `uvicorn api_interface:app --reload` to start the API.
+3. Provide any missing environment variables when prompted on startup.
+
 
 ## Installation
+Clone the repository and install the package using `pip`. Installing in
+standard (non-editable) mode keeps the source read-only:
 ```bash
 git clone https://github.com/snagori28/zeroth-ai-framework.git
 cd zeroth-ai-framework
-pip install -e .
+pip install .
 ```
+If you wish to hack on the framework itself, use `pip install -e .` instead.
 
 ## Usage
 ### Command line
+Run the interactive shell. If required environment variables are not already set you will be asked for them:
 ```bash
 python cli_interface.py
 ```
+You will be presented with a numbered menu for planning, learning new facts and ingesting documents. Choose "Exit" to quit.
 
 ### REST API
+Start the HTTP server with:
 ```bash
 uvicorn api_interface:app --reload
 ```
+This exposes the endpoints described below.
+
 
 ### API endpoints
 | Endpoint       | Description                                |
@@ -41,13 +54,19 @@ uvicorn api_interface:app --reload
 | `/explain`     | Return a step-by-step reasoning trace      |
 
 ## Environment variables
-Set these variables before running Zeroth:
+The CLI and API will prompt for any required values that are missing. You may also export them manually:
 ```bash
 export NEO4J_URI=bolt://localhost:7687
 export NEO4J_USER=neo4j
 export NEO4J_PASSWORD=your_password
 export OPENAI_API_KEY=your_openai_key
+# Optional variables:
+export UPLOAD_DIR=/path/to/uploads
+export LOG_LEVEL=INFO
+export MAX_UPLOAD_SIZE_MB=5
 ```
+You can also pre-set these values in your shell if you do not want to be prompted each time.
+
 
 ## Running tests
 ```bash

--- a/api_interface.py
+++ b/api_interface.py
@@ -2,7 +2,7 @@ import os
 import logging
 from fastapi import FastAPI
 from pydantic import BaseModel
-from config import Config
+from config import Config, ensure_env_vars
 from core.planner_agent import PlannerAgent
 from core.memory_agent import MemoryAgent
 from core.reasoner_agent import ReasonerAgent
@@ -11,6 +11,9 @@ from core.explainer_agent import ExplainerAgent
 from core.document_ingestor import DocumentIngestor
 
 logger = logging.getLogger(__name__)
+
+# Prompt for required configuration at startup
+ensure_env_vars()
 
 app = FastAPI()
 planner = PlannerAgent()

--- a/cli_interface.py
+++ b/cli_interface.py
@@ -5,10 +5,13 @@ from core.reasoner_agent import ReasonerAgent
 from core.llm_agent import LLM_Agent
 from core.explainer_agent import ExplainerAgent
 from core.document_ingestor import DocumentIngestor
-from config import Config
+from config import Config, ensure_env_vars
 
 def main():
     """Launch the interactive command line interface."""
+
+    # Ask for any configuration values that are not provided via environment.
+    ensure_env_vars()
 
     planner = PlannerAgent()
     memory = MemoryAgent()

--- a/config.py
+++ b/config.py
@@ -3,6 +3,8 @@ import logging
 from pathlib import Path
 
 class Config:
+    """Simple configuration container populated from environment variables."""
+
     # Neo4j Settings
     NEO4J_URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
     NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
@@ -19,6 +21,31 @@ class Config:
 
     # Security or future config placeholders
     MAX_UPLOAD_SIZE_MB = int(os.getenv("MAX_UPLOAD_SIZE_MB", 5))
+
+
+def ensure_env_vars():
+    """Prompt for required environment variables if they are missing."""
+
+    required = {
+        "NEO4J_URI": Config.NEO4J_URI,
+        "NEO4J_USER": Config.NEO4J_USER,
+        "NEO4J_PASSWORD": Config.NEO4J_PASSWORD,
+        "OPENAI_API_KEY": Config.OPENAI_API_KEY,
+    }
+
+    for var, value in required.items():
+        if not value:
+            entered = input(f"Enter value for {var}: ").strip()
+            os.environ[var] = entered
+
+    # reload configuration values from environment
+    Config.NEO4J_URI = os.getenv("NEO4J_URI", Config.NEO4J_URI)
+    Config.NEO4J_USER = os.getenv("NEO4J_USER", Config.NEO4J_USER)
+    Config.NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", Config.NEO4J_PASSWORD)
+    Config.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", Config.OPENAI_API_KEY)
+    Config.UPLOAD_DIR = os.getenv("UPLOAD_DIR", Config.UPLOAD_DIR)
+    Config.LOG_LEVEL = os.getenv("LOG_LEVEL", Config.LOG_LEVEL)
+    Config.MAX_UPLOAD_SIZE_MB = int(os.getenv("MAX_UPLOAD_SIZE_MB", Config.MAX_UPLOAD_SIZE_MB))
 
 
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- add `ensure_env_vars` helper that asks for missing environment variables
- call it in `cli_interface` and `api_interface`
- update README instructions about environment variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853110a9880832c916d2a1c149681e3