### PR TITLE
Fix path sanitization for uploads

### DIFF
--- a/api_interface.py
+++ b/api_interface.py
@@ -87,10 +87,16 @@ def ingest(req: IngestRequest):
 def ingest_file(req: IngestFileRequest):
     """Load a text file from the upload directory and ingest its contents."""
 
-    filepath = os.path.join(Config.UPLOAD_DIR, req.filename)
+    base_dir = os.path.abspath(Config.UPLOAD_DIR)
+    filepath = os.path.abspath(os.path.join(base_dir, req.filename))
     logger.info("/ingest-file loading %s", filepath)
+
+    if not filepath.startswith(base_dir + os.sep):
+        return {"error": "Invalid filename"}
+
     if not os.path.exists(filepath):
         return {"error": "File not found"}
+
     with open(filepath, "r", encoding="utf-8") as file:
         content = file.read()
     ingestor.ingest(content)

--- a/cli_interface.py
+++ b/cli_interface.py
@@ -72,7 +72,11 @@ def main():
 
                 if doc_option == '2':
                     filename = input(f"Enter filename (from {Config.UPLOAD_DIR}): ").strip()
-                    filepath = os.path.join(Config.UPLOAD_DIR, filename)
+                    base_dir = os.path.abspath(Config.UPLOAD_DIR)
+                    filepath = os.path.abspath(os.path.join(base_dir, filename))
+                    if not filepath.startswith(base_dir + os.sep):
+                        print("Invalid file path.")
+                        continue
                     if not os.path.exists(filepath):
                         print("File not found.")
                         continue


### PR DESCRIPTION
## Summary
- sanitize filename paths in API and CLI to prevent path traversal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853162bd3a8832c9d232761a2e5380f