### PR TITLE
Add ClarifierAgent for follow-up questions

### DIFF
--- a/cli_interface.py
+++ b/cli_interface.py
@@ -6,6 +6,7 @@ from core.llm_agent import LLM_Agent
 from core.explainer_agent import ExplainerAgent
 from core.document_ingestor import DocumentIngestor
 from core.feedback_agent import FeedbackAgent
+from core.clarifier_agent import ClarifierAgent
 from config import Config, ensure_env_vars
 
 def main():
@@ -18,6 +19,7 @@ def main():
     memory = MemoryAgent()
     llm = LLM_Agent()
     feedback = FeedbackAgent(llm)
+    clarifier = ClarifierAgent(llm_agent=llm)
     reasoner = ReasonerAgent(llm_agent=llm)
     explainer = ExplainerAgent(llm_agent=llm)
     ingestor = DocumentIngestor(llm, memory, feedback)
@@ -40,6 +42,11 @@ def main():
                 # Reset explanation trace for each new reasoning cycle
                 explanation_trace = []
                 user_goal = input("Enter your goal: ").strip()
+                follow_ups = clarifier.clarify(user_goal)
+                for q in follow_ups:
+                    ans = input(f"{q} ").strip()
+                    if ans:
+                        user_goal += f"\n{q}: {ans}"
                 subtasks = planner.plan(user_goal)
                 known_facts = []
 

--- a/core/clarifier_agent.py
+++ b/core/clarifier_agent.py
@@ -1,0 +1,25 @@
+import logging
+from .llm_agent import LLM_Agent
+
+logger = logging.getLogger(__name__)
+
+class ClarifierAgent:
+    """Generate clarifying questions for an ambiguous user goal."""
+
+    def __init__(self, llm_agent=None):
+        self.llm_agent = llm_agent or LLM_Agent()
+
+    def clarify(self, goal, num_questions=3):
+        """Return a list of follow-up questions about the goal."""
+        prompt = (
+            f"Ask {num_questions} short questions to better understand the request: '{goal}'. "
+            "Return each question on a new line."
+        )
+        try:
+            response = self.llm_agent.query(prompt, mode="creative")
+            questions = [q.strip('- ').strip() for q in response.split('\n') if q.strip()]
+            return questions[:num_questions]
+        except Exception as e:
+            logger.error("Clarifier LLM failed: %s", e)
+            return []
+

--- a/tests/test_clarifier_agent.py
+++ b/tests/test_clarifier_agent.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# minimal openai stub
+openai_stub = types.ModuleType("openai")
+class _DummyChat:
+    @staticmethod
+    def create(*a, **k):
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="Q1\nQ2\nQ3"))])
+openai_stub.ChatCompletion = _DummyChat
+openai_stub.api_key = None
+sys.modules["openai"] = openai_stub
+
+import importlib
+import core.llm_agent as llm_mod
+importlib.reload(llm_mod)
+from core.llm_agent import LLM_Agent
+import core.clarifier_agent as clarifier_mod
+importlib.reload(clarifier_mod)
+from core.clarifier_agent import ClarifierAgent
+
+
+def test_clarifier_returns_list(monkeypatch):
+    monkeypatch.setattr(LLM_Agent, "query", lambda self, prompt, mode="creative": "Q1\nQ2\nQ3")
+    agent = ClarifierAgent(llm_agent=LLM_Agent())
+    questions = agent.clarify("goal")
+    assert questions == ["Q1", "Q2", "Q3"]
+


### PR DESCRIPTION
## Summary
- introduce `ClarifierAgent` to generate clarifying questions using the LLM
- integrate the new agent into the CLI so users are asked follow-up questions before planning
- add tests for the clarifier agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532ae2f698832ca4afdaa119abefa6