### PR TITLE
Add ClarifierAgent and /clarify endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This exposes the endpoints described below.
 | `/ingest`      | Ingest raw text and store extracted facts  |
 | `/ingest-file` | Ingest a text file from `uploads/`         |
 | `/explain`     | Return a step-by-step reasoning trace      |
+| `/clarify`     | Generate clarifying questions for a goal   |
 
 ## Environment variables
 The CLI and API will prompt for any required values that are missing. You may also export them manually:

--- a/api_interface.py
+++ b/api_interface.py
@@ -10,6 +10,7 @@ from core.llm_agent import LLM_Agent
 from core.explainer_agent import ExplainerAgent
 from core.document_ingestor import DocumentIngestor
 from core.feedback_agent import FeedbackAgent
+from core.clarifier_agent import ClarifierAgent
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ feedback = FeedbackAgent(llm)
 reasoner = ReasonerAgent(llm_agent=llm)
 explainer = ExplainerAgent(llm_agent=llm)
 ingestor = DocumentIngestor(llm, memory, feedback)
+clarifier = ClarifierAgent(llm_agent=llm)
 
 
 @app.on_event("shutdown")
@@ -115,3 +117,12 @@ def explain(req: TaskRequest):
     steps = [f"Task: {task} -> Result: {fact}" for task, fact in zip(subtasks, known_facts)]
     steps.append(f"Final Inference: {reasoning}")
     return {"explanation": explainer.explain(steps)}
+
+
+@app.post("/clarify")
+def clarify(req: TaskRequest):
+    """Return clarifying questions for the user's goal."""
+
+    logger.info("/clarify called with goal: %s", req.goal)
+    questions = clarifier.clarify(req.goal)
+    return {"questions": questions}

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,19 @@
+from .planner_agent import PlannerAgent
+from .reasoner_agent import ReasonerAgent
+from .explainer_agent import ExplainerAgent
+from .llm_agent import LLM_Agent
+from .memory_agent import MemoryAgent
+from .document_ingestor import DocumentIngestor
+from .feedback_agent import FeedbackAgent
+from .clarifier_agent import ClarifierAgent
+
+__all__ = [
+    "PlannerAgent",
+    "ReasonerAgent",
+    "ExplainerAgent",
+    "LLM_Agent",
+    "MemoryAgent",
+    "DocumentIngestor",
+    "FeedbackAgent",
+    "ClarifierAgent",
+]

--- a/core/clarifier_agent.py
+++ b/core/clarifier_agent.py
@@ -1,0 +1,24 @@
+import logging
+from .llm_agent import LLM_Agent
+
+logger = logging.getLogger(__name__)
+
+class ClarifierAgent:
+    """Generate clarifying questions for a given goal."""
+
+    def __init__(self, llm_agent=None):
+        self.llm_agent = llm_agent or LLM_Agent()
+
+    def clarify(self, goal, num_questions=3):
+        """Return a list of clarifying questions."""
+        prompt = (
+            f"Provide {num_questions} clarifying questions that would help better understand the following goal:\n{goal}"
+        )
+        try:
+            text = self.llm_agent.query(prompt, mode="factual")
+            questions = [q.strip('- ').strip() for q in text.split('\n') if q.strip()]
+            return questions
+        except Exception as e:
+            logger.error("Clarification failed: %s", e)
+            return []
+

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -25,6 +25,20 @@ openai_stub.ChatCompletion = _DummyChat
 openai_stub.api_key = None
 sys.modules["openai"] = openai_stub
 
+# minimal spacy stub
+spacy_stub = types.ModuleType("spacy")
+class _DummyDoc:
+    def __init__(self, text=""):
+        self.text = text
+        self.noun_chunks = []
+    def similarity(self, other):
+        return 0.0
+class _DummyNLP:
+    def __call__(self, text):
+        return _DummyDoc(text)
+spacy_stub.load = lambda name: _DummyNLP()
+sys.modules.setdefault("spacy", spacy_stub)
+
 from core.planner_agent import PlannerAgent
 from core.reasoner_agent import ReasonerAgent
 from core.explainer_agent import ExplainerAgent

--- a/tests/test_api_clarify.py
+++ b/tests/test_api_clarify.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import types
+import importlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# minimal openai stub
+openai_stub = types.ModuleType("openai")
+class _DummyChat:
+    @staticmethod
+    def create(*a, **k):
+        raise NotImplementedError
+openai_stub.ChatCompletion = _DummyChat
+openai_stub.api_key = None
+sys.modules["openai"] = openai_stub
+
+# minimal neo4j stub
+neo4j_stub = types.ModuleType("neo4j")
+class _DummyGraphDatabase:
+    @staticmethod
+    def driver(*a, **k):
+        raise NotImplementedError
+neo4j_stub.GraphDatabase = _DummyGraphDatabase
+sys.modules["neo4j"] = neo4j_stub
+
+from fastapi.testclient import TestClient
+
+# minimal spacy stub
+spacy_stub = types.ModuleType("spacy")
+class _DummyDoc:
+    def __init__(self, text=""):
+        self.text = text
+        self.noun_chunks = []
+    def similarity(self, other):
+        return 0.0
+class _DummyNLP:
+    def __call__(self, text):
+        return _DummyDoc(text)
+spacy_stub.load = lambda name: _DummyNLP()
+sys.modules["spacy"] = spacy_stub
+
+
+def _dummy_response(text):
+    msg = types.SimpleNamespace(content=text)
+    choice = types.SimpleNamespace(message=msg)
+    return types.SimpleNamespace(choices=[choice])
+
+
+def test_clarify_endpoint(monkeypatch):
+    # Ensure required env vars so import does not prompt
+    monkeypatch.setenv("NEO4J_URI", "bolt://test")
+    monkeypatch.setenv("NEO4J_USER", "neo4j")
+    monkeypatch.setenv("NEO4J_PASSWORD", "pass")
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+
+    import config
+    importlib.reload(config)
+
+    # Dummy Neo4j driver to satisfy MemoryAgent
+    class DummySession:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def run(self, *a, **k):
+            return types.SimpleNamespace(single=lambda: None, data=lambda: [])
+    class DummyDriver:
+        def session(self):
+            return DummySession()
+    monkeypatch.setattr(neo4j_stub.GraphDatabase, "driver", lambda *a, **k: DummyDriver())
+    monkeypatch.setattr(openai_stub.ChatCompletion, "create", lambda **k: _dummy_response("Q1\nQ2"))
+
+    import api_interface
+    importlib.reload(api_interface)
+    monkeypatch.setattr(api_interface.clarifier.llm_agent, "query", lambda *a, **k: "Q1\nQ2")
+
+    client = TestClient(api_interface.app)
+    resp = client.post("/clarify", json={"goal": "test goal"})
+    assert resp.status_code == 200
+    assert resp.json() == {"questions": ["Q1", "Q2"]}


### PR DESCRIPTION
## Summary
- add ClarifierAgent implementation
- expose ClarifierAgent in core package and instantiate in API
- provide /clarify endpoint returning clarifying questions
- document new endpoint in README
- add API test and spacy stubs for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68533020a6a4832cb1f963d3a3235134