### PR TITLE
Update README with ClarifierAgent info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ Zeroth is a lightweight, reasoning-first AI engine. It breaks a goal into clear 
 For a deeper look at the project's philosophy and detailed use cases, see the [WHITEPAPER](WHITEPAPER.md).
 
 ## Features
-- **Agent architecture** – Planner, Memory, Reasoner, Explainer, LLM and DocumentIngestor
+- **Agent architecture** – Planner, Memory, Reasoner, Explainer, Clarifier, Feedback, LLM and DocumentIngestor
+- **LLM‑first planning** – goals are broken down with an LLM and spaCy fallback
 - **Dual LLM modes** – factual or creative queries depending on the task
-- **Persistent graph memory** – facts are stored in Neo4j for later retrieval
+- **Persistent graph memory** – facts are stored in Neo4j with synonym search
 - **Explainable reasoning** – every step can be traced and explained to the user
+- **Document ingestion** – parse text files and validate facts automatically
+- **FeedbackAgent** – confirms or edits LLM‑suggested facts before saving
+- **ClarifierAgent** – asks follow-up questions to refine ambiguous goals
 - **CLI and REST API** – interact either from the command line or over HTTP
-- **Document ingestion** – parse text files and extract facts automatically
 ## Quick start
 1. **Install the package** (see Installation below).
 2. **Run** `python cli_interface.py` for the CLI or `uvicorn api_interface:app --reload` to start the API.
@@ -33,7 +36,9 @@ Run the interactive shell. If required environment variables are not already set
 ```bash
 python cli_interface.py
 ```
-You will be presented with a numbered menu for planning, learning new facts and ingesting documents. Choose "Exit" to quit.
+You will be presented with a numbered menu for planning, learning new facts and ingesting documents.
+During planning the CLI may ask follow‑up questions via the ClarifierAgent. If new facts are suggested by the LLM you can accept, edit or reject them with help from the FeedbackAgent.
+Respond to these prompts to refine your goal or store corrected facts. Choose "Exit" to quit.
 
 ### REST API
 Start the HTTP server with:

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -20,10 +20,12 @@ Build a lightweight, offline-friendly, explainable AI engine that is developer-f
 - **Explainability**: Clear, human-readable reasoning.
 - **Resource Efficiency**: Run where GPUs can’t.
 ## ⚙️ Key Features
-- Modular agent architecture (Planner, Memory, Reasoner, Explainer, LLM and Ingestor)
+- Modular agent architecture (Planner, Memory, Reasoner, Explainer, Clarifier, Feedback, LLM and Ingestor)
+- LLM-first planning with spaCy fallback
 - Dual LLM modes for factual or creative reasoning
-- Neo4j-backed graph memory
-- Explainable, step-by-step output
+- Graph memory with synonym search and fuzzy matching
+- Document ingestion with fact validation
+- Chain-of-thought reasoning traces
 - Works offline with minimal LLM use
 
 ---
@@ -33,9 +35,10 @@ Build a lightweight, offline-friendly, explainable AI engine that is developer-f
 Example workflow:
 1. Planner breaks a goal like “Plan Mars mission” into subtasks.
 2. Memory checks what’s already known.
-3. Reasoner makes deductions from known facts.
-4. LLM is consulted *only* if something critical is missing.
-5. Explainer compiles a full trace of how it reached the answer.
+3. ClarifierAgent asks follow‑up questions if a subtask is unclear.
+4. Reasoner makes deductions from known facts with chain‑of‑thought prompts.
+5. FeedbackAgent validates any new facts suggested by the LLM.
+6. Explainer compiles a full trace of how Zeroth reached the answer.
 
 ---
 


### PR DESCRIPTION
## Summary
- mention ClarifierAgent as part of the agent architecture
- highlight that CLI follow-up questions refine the goal
- document FeedbackAgent and new planning features across README and WHITEPAPER

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685330218abc832c9e94bf3e47631305